### PR TITLE
fix: Ensure title is direct child of rfc-entry

### DIFF
--- a/lib/rfc.rb
+++ b/lib/rfc.rb
@@ -19,8 +19,10 @@ module VimRFC
     def start_element(elem, attrs = [])
       case elem
       when 'rfc-entry', 'std-entry' then @in_entry = true
+                                         @in_other_elem = 0
       when 'doc-id'                 then @in_docid = true
-      when 'title'                  then @in_title = true
+      when 'title'                  then if @in_other_elem==0 then @in_title = true end
+      else if @in_entry then @in_other_elem += 1 end
       end
     end
 
@@ -29,6 +31,7 @@ module VimRFC
       when 'rfc-entry', 'std-entry' then @in_entry = false
       when 'doc-id'                 then @in_docid = false
       when 'title'                  then @in_title = false
+      else if @in_entry then @in_other_elem -= 1 end
       end
     end
 


### PR DESCRIPTION
So far, the title was set to the last `title` element found within a `rfc-entry`. But that happened regardless of whether `title` was actually a direct child of `rfc-entry`. This assumption is not always correct, as in the following example:

```
<rfc-entry>
        <doc-id>RFC7230</doc-id>
        <title>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</title>
        <author>
            <name>R. Fielding</name>
            <title>Editor</title>
        </author>
        [...]
</rfc-entry>
```

Here, the cached title should be "Hypertext Transfer Protocol ...". Instead it was the `title` element in the `author` element, that is "Editor".

PS: Thanks a lot for this plug-in!
