### PR TITLE
Fix: error upon hitting <CR>: "private method 'eval' called by Vim:Mo…

### DIFF
--- a/autoload/rfc.vim
+++ b/autoload/rfc.vim
@@ -78,7 +78,7 @@ function! s:open_entry_by_cr()
   else
     ruby << EOF
     require 'open-uri'
-    body = URI.parse(VIM::eval('url')).read
+    body = URI.parse(VIM::evaluate('url')).read
     VIM::command("enew | append #{body}")
     VIM::command('0')
 EOF


### PR DESCRIPTION
…dule"

I'm not sure of why I apparently am the only one getting this error, but
this change fixes it on my vim ('evaluate' is the correct name to use
according to :help ruby).

Awesome plugin by the way.