### PR TITLE
12: Updated root namespace to use https

### DIFF
--- a/autoload/rfc.vim
+++ b/autoload/rfc.vim
@@ -121,7 +121,7 @@ def create_cache_file():
 
   # 3.8 introduced the any-ns syntax: '{*}tag',
   # but let's go the old way for compatability.
-  ns = {'ns': 'http://www.rfc-editor.org/rfc-index'}
+  ns = {'ns': 'https://www.rfc-editor.org/rfc-index'}
 
   with open(os.path.expanduser(cache_dir + '/vim-rfc.txt'), 'w') as f:
     for entry in root.findall('ns:rfc-entry', ns):


### PR DESCRIPTION
Currently the namespace from the index XML only has the https version.

Fixes: https://github.com/mhinz/vim-rfc/issues/12