### PR TITLE
feat(rfc): add section reference matching and update namespace URL

### DIFF
--- a/autoload/rfc.vim
+++ b/autoload/rfc.vim
@@ -121,7 +121,7 @@ def create_cache_file():
 
   # 3.8 introduced the any-ns syntax: '{*}tag',
   # but let's go the old way for compatability.
-  ns = {'ns': 'http://www.rfc-editor.org/rfc-index'}
+  ns = {'ns': 'https://www.rfc-editor.org/rfc-index'}
 
   with open(os.path.expanduser(cache_dir + '/vim-rfc.txt'), 'w') as f:
     for entry in root.findall('ns:rfc-entry', ns):

--- a/ftplugin/rfc.vim
+++ b/ftplugin/rfc.vim
@@ -43,6 +43,11 @@ function! s:rfcTag()
     let l = '^\c\V' . lm
     call add(b:backposes, getpos('.'))
     call search(l, 'Ws')
+  elseif syn == 'rfcSecRef'
+    let l = s:get_pattern_at_cursor('\vSection \d(\.\d)*')
+    let l = substitute(l, '\v^Section\s+', '', '')
+    let l = '\v^' . l
+    call search(l, 'Ws')
   elseif syn == 'rfcReference'
     let l = s:get_pattern_at_cursor('\[\w\+\]')
     if l == ''

--- a/syntax/rfc.vim
+++ b/syntax/rfc.vim
@@ -20,6 +20,7 @@ syn match rfcRFC	/\v.@<=%(RFC|STD)\s+[0-9]+|ANSI\s+[0-9A-Z-.]+/ containedin=ALL
 syn match rfcReference	/^\@<!\[\w\+\]/
 syn match rfcComment	/^\S.*\ze\n/
 syn match rfcDots	/\v\.\.+\ze\d+$/ contained
+syn match rfcSecRef	/\vSection \d(\.\d)*/
 syn match rfcContents	/^\v\s+(([A-Z]\.)?([0-9]+\.?)+|Appendix|Full Copyright Statement).*(\n.*)?(\s|\.)\d+$/ contains=rfcDots
 syn keyword rfcNote	NOTE note: Note: NOTE: Notes Notes:
 " Highlight [sic] here so it won't be highlighted as rfcReference
@@ -34,6 +35,7 @@ hi link rfcComment	Comment
 hi link rfcReference	Number
 hi link rfcDots		Comment
 hi link rfcContents	Tag
+hi link rfcSecRef	Tag
 hi link rfcKeyword	Keyword
 
 let b:current_syntax = "rfc"


### PR DESCRIPTION
Description:
Overview:
This pull request introduces the following enhancements to the RFC syntax highlighting plugin:

Section Reference Matching:
A new regular expression (rfcSecRef) has been added to match RFC section references such as Section 3.1.1, Section 3.2, and others. This feature allows better handling of RFC documents that include sections formatted in this way.

Updated Namespace URL:
The namespace URL used in the cache file has been updated from http://www.rfc-editor.org/rfc-index to the more current https://www.rfc-editor.org/rfc-index. This ensures compatibility with the updated RFC index URL.

Changes:
Added a new syntax rule:
The rfcSecRef regular expression was introduced to match section references like Section 3.1, Section 3.2.1, etc., and applied it to enhance RFC document navigation.

Namespace URL Update:
The URL was updated for better compatibility and to follow the latest standard from the RFC Editor.